### PR TITLE
Update models.go

### DIFF
--- a/wallet/models.go
+++ b/wallet/models.go
@@ -162,7 +162,7 @@ type ValidateAddressResponse struct {
 	// Specifies which of the three Monero networks (mainnet, stagenet, and testnet) the address belongs to.
 	Nettype string `json:"nettype"`
 	// True if the address is OpenAlias-formatted.
-	OpenaliasAddress bool `json:"openalias_address"`
+	OpenaliasAddress string `json:"openalias_address"`
 }
 
 // GetAccountsRequest represents the request model for GetAccounts


### PR DESCRIPTION
Found a bug in variable type of ValidateAddressResponse:

> cannot unmarshal string into Go struct field ValidateAddressResponse.openalias_address of type bool


Actual result of this request using curl shows that "openalias_address" is type string, not bool:

```
curl http://127.0.0.1:18082/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"validate_address","params":{"address":"42go2d3XqA9Mx4HjZoqr93BHspcMxwAUBivs3yJKV1FyTycEcbgjNyEaGNEcgnUE9DDDAXNanzB16YgMt88Sa8cFSm2QcHK","any_net_type":true,"allow_openalias":true},' -H 'Content-Type: application/json' 
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "integrated": false,
    "nettype": "mainnet",
    "openalias_address": "",
    "subaddress": false,
    "valid": true
  }
}
```

source: https://www.getmonero.org/resources/developer-guides/wallet-rpc.html#validate_address