### PR TITLE
fix: treat empty JSON-RPC error (code=0) as null result

### DIFF
--- a/monerorpc.go
+++ b/monerorpc.go
@@ -76,6 +76,13 @@ func (c *MoneroRPC) Do(method string, req interface{}, res interface{}) error {
 		if err == json2.ErrNullResult {
 			return nil
 		}
+		// Some monero-wallet-rpc versions return {"error":{"code":0,"message":""}}
+		// instead of an empty result (e.g. get_transfers with pool:true when the pool
+		// is empty). Code 0 with no message is not a valid JSON-RPC error — treat it
+		// the same as a null result.
+		if rpcErr, ok := err.(*json2.Error); ok && rpcErr.Code == 0 && rpcErr.Message == "" && rpcErr.Data == nil {
+			return nil
+		}
 	}
 
 	return err


### PR DESCRIPTION
## Summary
- Some `monero-wallet-rpc` versions return `{"error":{"code":0,"message":""}}` instead of an empty result
- Reproduced on `get_transfers` with `pool:true` when the pool is empty
- `code=0` with an empty message is not a valid JSON-RPC error per spec
- Added a check: if `*json2.Error` has `Code == 0`, `Message == ""` and `Data == nil` — treat it the same as a null result
- Behaviour is consistent with the existing `ErrNullResult` handling

## Problem
`Do()` returned an error for successful calls when the daemon responded with `{"error":{"code":0,"message":""}}`,
blocking correct empty-response handling on the client side.

## Test plan
- [ ] Call `get_transfers` with `pool:true` on a node with an empty pool — no error returned
- [ ] Real JSON-RPC errors (non-zero `code`) are still propagated correctly
- [ ] `ErrNullResult` is still handled as before