### PR TITLE
Feat/all accounts get transfers

### DIFF
--- a/wallet/models.go
+++ b/wallet/models.go
@@ -856,6 +856,8 @@ type GetTransfersRequest struct {
 	AccountIndex uint32 `json:"account_index,omitempty"`
 	// (Optional) List of subaddress indices to query for transfers. (Defaults to empty - all indices)
 	SubaddrIndices []uint32 `json:"subaddr_indices,omitempty"`
+	// (Optional) If true, return transfers for all accounts; account_index and subaddr_indices are ignored.
+	AllAccounts bool `json:"all_accounts,omitempty"`
 }
 
 // Transfer model


### PR DESCRIPTION
## Summary
- Added `AllAccounts bool` field to `GetTransfersRequest` in `wallet/models.go`
- Allows querying transfers across all accounts in a single `get_transfers` call
- When `all_accounts: true`, the daemon ignores `account_index` and `subaddr_indices`
- Field is optional (`omitempty`) — fully backwards compatible

## Files
- `wallet/models.go` — added `AllAccounts bool` with JSON tag `all_accounts,omitempty`

## Test plan
- [ ] Call `get_transfers` with `all_accounts: true` — transfers from all accounts are returned
- [ ] Call without the field — behaviour unchanged, `account_index` is respected as before
- [ ] Field is not serialized to JSON when `false` (omitempty)